### PR TITLE
新規登録の仕様変更対応

### DIFF
--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -20,6 +20,8 @@
 
   &__inner {
     width: 680px;
+    min-height: 1800px;
+    height: auto !important;
     height: 1800px;
     margin: 10px auto;
     padding: 60px;
@@ -140,7 +142,6 @@
 
   input[type='submit'] {
     float: left;
-    margin-top: 20px;
     color: #fff;
     background-color: #38aef0;
   }

--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -67,6 +67,7 @@
       width: 200px;
       height: 48px;
     }
+
     .field-label {
       margin-left: 180px;
       padding: 10px 0;
@@ -116,8 +117,12 @@
       }
     }
 
-    .year,.month,.day{
+    .year{
       width: 10%;
+      height: 30px;
+     }
+    .month,.day{
+      width: 8%;
       height: 30px;
      }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,9 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birthday, :destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number])
+    devise_parameter_sanitizer.permit(:sign_up, 
+      keys: [:birthday, :phone_number, :family_name, :first_name, :family_name_kana, :first_name_kana,  
+        destination_attributes: [:destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :postal_code, :prefecture_id, :city, :street_block, :mansion_name, :nickname]])
   end
 
   def production?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,7 @@ class ItemsController < ApplicationController
 
   # 商品詳細表示のアクション
   def show
+    @destination = Destination.find_by(user_id: @item.seller_id)
   end
 
   # 商品削除のアクション
@@ -54,7 +55,7 @@ class ItemsController < ApplicationController
   end
 
   def set_itme
-    @item = Item.find(params[:id]) 
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,16 +6,20 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # GET /resource/sign_up
   def new
-    super
+    @user = User.new
+    @user.build_destination
   end
 
+ 
   # POST /resource
   def create
     @user = User.new(user_params)
     unless @user.valid?
-      flash.now[:alert] = @user.errors.full_messages
       render :new and return
     end
+    @user.save
+    sign_in @user
+    redirect_to root_path
   end
 
   # GET /resource/edit
@@ -43,10 +47,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  #   devise_parameter_sanitizer.permit(:sign_up,
+  #     keys: [:birthday, :phone_number, :family_name, :first_name, :family_name_kana, :first_name_kana,  
+  #       destination_attributes: [:destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :postal_code, :prefecture_id, :city, :street_block, :mansion_name, :nickname]])
   # end
 
   # If you have extra params to permit, append them to the sanitizer.
@@ -61,10 +65,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
+  #  :new_item(resource)
   # end
-private
-def user_params
-  params.require(:user).permit(:nickname, :email, :password, :family_name, :first_name, :family_name_kana, :first_name_kana, :birthday, :destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number)
-end
+
+  private
+  def user_params
+    #params.require(:user).permit(:nickname, :email, :password, :family_name, :first_name, :family_name_kana, :first_name_kana, :birthday, :destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :postal_code, :prefecture_id, :city, :street_block, :mansion_name)
+    params.require(:user).permit(:email, :password, :password_confirmation, :family_name, :first_name, :family_name_kana, :first_name_kana, :birthday, :phone_number,
+            destination_attributes: [:destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :postal_code, :prefecture_id, :city, :street_block, :mansion_name, :nickname])
+  end
+
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,21 +1,21 @@
 class Destination < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, inverse_of: :destination
 
-  with_options presence: true do
-    validates :family_name
-    validates :family_name_kana
-    validates :first_name
-    validates :first_name_kana
-    validates :postalcode
-    validates :prefecture
-    validates :city
-    validates :address
-    validates :prefecture_id
-  end
+  validates :destination_family_name, presence: true,
+  format: { with: /[^-｡-ﾟ]+/}
+  validates :destination_first_name, presence: true,
+  format: { with: /[^-｡-ﾟ]+/}
+  validates :destination_family_name_kana, presence: true,
+  format: { with: /[^-｡-ﾟ]+/}
+  validates :destination_first_name_kana, presence: true,
+  format: { with: /[^-｡-ﾟ]+/}
+  validates :postal_code, presence: true
+  validates :prefecture_id, presence: true
+  validates :city, presence: true
+  validates :street_block, presence: true
+  validates :nickname, presence: true
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
 
 end
-
-  

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :reviews, dependent: :destroy
-  has_one :destination, inverse_of: :user
+  has_one :destination, inverse_of: :user, dependent: :destroy
   accepts_nested_attributes_for :destination
   
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,14 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :reviews, dependent: :destroy
+  has_one :destination, inverse_of: :user
+  accepts_nested_attributes_for :destination
+  
+
+  validates_associated :destination
 
   VALID_EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
-  validates :nickname, presence: true
   validates :password, presence: true, length: { minimum: 7}
   validates :family_name, presence: true,
   format: { with: /[^-｡-ﾟ]+/}
@@ -22,17 +26,6 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true,
   format: { with: /[^-｡-ﾟ]+/}
   validates :birthday, presence: true
-  validates :destination_family_name, presence: true,
-  format: { with: /[^-｡-ﾟ]+/}
-  validates :destination_first_name, presence: true,
-  format: { with: /[^-｡-ﾟ]+/}
-  validates :destination_family_name_kana, presence: true,
-  format: { with: /[^-｡-ﾟ]+/}
-  validates :destination_first_name_kana, presence: true,
-  format: { with: /[^-｡-ﾟ]+/}
-  validates :postal_code, presence: true
-  validates :prefecture_id, presence: true
-  validates :city, presence: true
-  validates :house_number, presence: true
+
 
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,12 +8,13 @@
     .account-page__inner--main.user-form
       = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
         = devise_error_messages!
-        .field
-          .field-label
-            = f.label 'ニックネーム'
-            %span.field-required 必須
-          .field-input
-            = f.text_field :nickname, placeholder: "（例）フリマ太郎", autofocus: true
+        = f.fields_for :destination do |destination|
+          .field
+            .field-label
+              = destination.label 'ニックネーム'
+              %span.field-required 必須
+            .field-input
+              = destination.text_field :nickname, placeholder: "（例）フリマ太郎", autofocus: true
         .field
           .field-label
             = f.label 'メールアドレス'
@@ -62,69 +63,63 @@
             = f.label '生年月日'
             %span.field-required 必須
           .field-input
-            -# != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'field-input_date', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
             != sprintf(f.date_select(:birthday, with_css_classes:'field-input_date', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
 
         .field
           .field-label
             = f.label '商品送付先情報'
-
-        .field
-          .field-label
-            = f.label '送付先氏名（全角）'
-            %span.field-required 必須
-          .field-input_flex
+        =f.fields_for :destination do |destination|
+          .field
+            .field-label
+              = destination.label '送付先氏名（全角）'
+              %span.field-required 必須
+            .field-input_flex
+              .field-input
+                = destination.text_field :destination_family_name, placeholder: "(例)山田"
+              .field-input.leftbox
+                = destination.text_field :destination_first_name, placeholder: "太郎"
+          .field
+            .field-label
+              = destination.label '送付先氏名カナ（全角）'
+              %span.field-required 必須
+            .field-input_flex
+              .field-input
+                = destination.text_field :destination_family_name_kana, placeholder: "(例)ヤマダ"
+              .field-input.leftbox
+                = destination.text_field :destination_first_name_kana, placeholder: "タロウ"
+          .field
+            .field-label
+              = destination.label '郵便番号'
+              %span.field-required 必須
             .field-input
-              = f.text_field :destination_family_name, placeholder: "(例)山田"
-            .field-input.leftbox
-              = f.text_field :destination_first_name, placeholder: "太郎"
-        .field
-          .field-label
-            = f.label '送付先氏名カナ（全角）'
-            %span.field-required 必須
-          .field-input_flex
+              = destination.text_field :postal_code, placeholder: "（例）123-4567"
+          .field
+            .field-label
+              = destination.label '都道府県（プルダウンからの選択）'
+              %span.field-required 必須
             .field-input
-              = f.text_field :destination_family_name_kana, placeholder: "(例)ヤマダ"
-            .field-input.leftbox
-              = f.text_field :destination_first_name_kana, placeholder: "タロウ"
+              = destination.collection_select :prefecture_id, Prefecture.all, :id, :name
+          .field
+            .field-label
+              = destination.label '市区町村'
+              %span.field-required 必須
+            .field-input
+              = destination.text_field :city, placeholder: "（例）横浜市緑区"
+          .field
+            .field-label
+              = destination.label '番地'
+              %span.field-required 必須
+            .field-input
+              = destination.text_field :street_block, placeholder: "（例）青山１−１−１"
+          .field
+            .field-label
+              = destination.label 'マンション・ビル名'
+            .field-input
+              = destination.text_field :mansion_name, placeholder: "（例）柳ビル 103"
 
         .field
           .field-label
-            =f.label '郵便番号'
-            %span.field-required 必須
-          .field-input
-            = f.text_field :postal_code, placeholder: "（例）123-4567"
-
-        .field
-          .field-label
-            = f.label '都道府県（プルダウンからの選択）'
-            %span.field-required 必須
-          .field-input
-            = f.collection_select :prefecture_id, Prefecture.all, :id, :name
-
-        .field
-          .field-label
-            = f.label '市区町村'
-            %span.field-required 必須
-          .field-input
-            = f.text_field :city, placeholder: "（例）横浜市緑区"
-
-        .field
-          .field-label
-            = f.label '番地'
-            %span.field-required 必須
-          .field-input
-            = f.text_field :house_number, placeholder: "（例）青山１−１−１"
-
-        .field
-          .field-label
-            = f.label 'マンション・ビル名'
-          .field-input
-            = f.text_field :building_name, placeholder: "（例）柳ビル 103"
-
-        .field
-          .field-label
-            = f.label 'お届け先電話番号(後住所系)'
+            = f.label 'お届け先電話番号'
           .field-input
             = f.text_field :phone_number, placeholder: "（例）123-4567-8910"
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -65,7 +65,7 @@
                   %th
                     出品者
                   %td
-                    =@item.seller.nickname
+                    =@destination.nickname
                 %tr
                   %th
                     カテゴリー

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-devise_for :users
+devise_for :users, controllers: {
+  registrations: 'users/registrations'
+}
+
 root 'items#index'
 resources :items, only: [:index, :show,:new,:create,:destroy] do
     collection do

--- a/db/migrate/20200819090421_devise_create_users.rb
+++ b/db/migrate/20200819090421_devise_create_users.rb
@@ -3,15 +3,13 @@
 class DeviseCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
-      t.string :nickname, null: false
-      t.string :icon
+
       t.string :family_name, null: false
       t.string :first_name, null: false
       t.string :family_name_kana, null: false
       t.string :first_name_kana, null: false
-      # t.string :phone_number 
       t.date :birthday, null: false
-      t.text :introduction
+
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
 

--- a/db/migrate/20200823121211_add_city_to_users.rb
+++ b/db/migrate/20200823121211_add_city_to_users.rb
@@ -1,14 +1,5 @@
 class AddCityToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :postal_code, :string
-    add_column :users, :prefecture_id, :integer
-    add_column :users, :city, :string
-    add_column :users, :house_number, :string
-    add_column :users, :building_name, :string
-    add_column :users, :destination_family_name, :string
-    add_column :users, :destination_first_name, :string
-    add_column :users, :destination_family_name_kana, :string
-    add_column :users, :destination_first_name_kana, :string
     add_column :users, :phone_number, :string
   end
 end

--- a/db/migrate/20200926102105_create_destinations.rb
+++ b/db/migrate/20200926102105_create_destinations.rb
@@ -1,0 +1,21 @@
+class CreateDestinations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :destinations do |t|
+
+      t.string :destination_family_name, null: false
+      t.string :destination_first_name, null: false
+      t.string :destination_family_name_kana, null: false
+      t.string :destination_first_name_kana, null: false
+      t.string :postal_code, null: false
+      t.integer :prefecture_id, null: false
+      t.string :city, null: false
+      t.string :street_block, null: false
+      t.string :mansion_name
+      t.integer :user_id, null: false, foreign_key: true
+      t.string :nickname, null: false
+      t.string :icon
+      t.text :introduction
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_065805) do
+ActiveRecord::Schema.define(version: 2020_09_26_102105) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -44,6 +44,24 @@ ActiveRecord::Schema.define(version: 2020_08_31_065805) do
   create_table "creditcards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "user_id", null: false
     t.string "token_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "destinations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "destination_family_name", null: false
+    t.string "destination_first_name", null: false
+    t.string "destination_family_name_kana", null: false
+    t.string "destination_first_name_kana", null: false
+    t.string "postal_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "street_block", null: false
+    t.string "mansion_name"
+    t.integer "user_id", null: false
+    t.string "nickname", null: false
+    t.string "icon"
+    t.text "introduction"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -95,14 +113,11 @@ ActiveRecord::Schema.define(version: 2020_08_31_065805) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "nickname", null: false
-    t.string "icon"
     t.string "family_name", null: false
     t.string "first_name", null: false
     t.string "family_name_kana", null: false
     t.string "first_name_kana", null: false
     t.date "birthday", null: false
-    t.text "introduction"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -110,15 +125,6 @@ ActiveRecord::Schema.define(version: 2020_08_31_065805) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "postal_code"
-    t.integer "prefecture_id"
-    t.string "city"
-    t.string "house_number"
-    t.string "building_name"
-    t.string "destination_family_name"
-    t.string "destination_first_name"
-    t.string "destination_family_name_kana"
-    t.string "destination_first_name_kana"
     t.string "phone_number"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
# What
ユーザ新規登録時の保存先をusersテーブルとdestinationsテーブルに分ける対応

# Why
ユーザ新規登録時、ユーザ情報と商品送付先情報の保存先をusersテーブル１つにしていたが、
ユーザマイページ作成時、usersテーブルの情報が更新できない、という事象が発生したため、
更新の予定がない情報をusersテーブル、更新の予定がある情報をdestinationsテーブルに保存する実装に変更する。
