### PR TITLE
商品購入機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'capistrano-rails-console'
   gem 'rspec-rails', '~> 4.0.0.beta2'
   gem 'factory_bot_rails'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.4.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -394,6 +398,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-controller-testing
   rspec-rails (~> 4.0.0.beta2)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -21,7 +21,7 @@ document.addEventListener(
             $("#exp_month").removeAttr("name");
             $("#exp_year").removeAttr("name"); 
             // name属性を削除することにより、dataベースに送るのを防ぐ。
-            $(".leftbox").append(
+            $("#card_token").append(
               $('<input type="hidden" name="payjp-token">').val(response.id)
               // <input type="hidden" name="payjp-token" value= response.id>が#card_tokenに追加される。
             ); 

--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -604,6 +604,7 @@
         }
         ul {
           margin-top: 32px;
+          margin-bottom: 64px;
           position: relative;
           li {
             

--- a/app/views/creditcards/_selection.html.haml
+++ b/app/views/creditcards/_selection.html.haml
@@ -14,5 +14,5 @@
       = form_tag(delete_creditcards_path, method: "POST", id: 'charge-form', name: "inputForm") do
         %input{ type: "hidden", name: "card_id", value: "" }
         %button 削除する
-    .change-creditcard
-      = link_to "新規カードを登録する", new_creditcard_path
+    -# .change-creditcard
+    -#   = link_to "新規カードを登録する", new_creditcard_path

--- a/app/views/creditcards/new.html.haml
+++ b/app/views/creditcards/new.html.haml
@@ -6,7 +6,7 @@
     .mypage__content__card
       %h3 クレジットカード情報入力
     .mypage__content__card__info
-      = form_with model: @creditcard, url: creditcards_path, local: true, html: { name: 'inputForm' }, id: "card_token" do |f| 
+      = form_with model: @creditcard, url: creditcards_path, local: true, html: { name: 'inputForm' } do |f| 
         .field
           .field-label
             = f.label 'カード番号'
@@ -28,7 +28,7 @@
             %span.field-required 必須
           .field-input
             = f.password_field :cvc, id: 'cvc',class: "card_form" ,maxlength: '6', placeholder: "カード背面4桁もしくは3桁の番号"
-        .actions
+        #card_token.actions
           = f.submit '登録', id: 'token_submit', class: "btn"
 
   .mypage__bottom

--- a/app/views/creditcards/new.html.haml
+++ b/app/views/creditcards/new.html.haml
@@ -6,7 +6,7 @@
     .mypage__content__card
       %h3 クレジットカード情報入力
     .mypage__content__card__info
-      = form_with model: @creditcard, url: creditcards_path, local: true, html: { name: 'inputForm' } do |f|
+      = form_with model: @creditcard, url: creditcards_path, local: true, html: { name: 'inputForm' }, id: "card_token" do |f| 
         .field
           .field-label
             = f.label 'カード番号'

--- a/app/views/creditcards/show.html.haml
+++ b/app/views/creditcards/show.html.haml
@@ -35,12 +35,12 @@
       .contents__payment--delivery
         %h3 配送先
         %p
-          = "〒" + @user.postal_code 
+          = "〒" + current_user.destination.postal_code 
         %p
-          - @prefecture = Prefecture.find @user.prefecture_id
-          = @prefecture.name + @user.city + @user.house_number
+          - @prefecture = Prefecture.find current_user.destination.prefecture_id
+          = @prefecture.name + current_user.destination.city + current_user.destination.street_block
         %p
-          = @user.destination_family_name_kana + @user.destination_first_name_kana
+          = current_user.destination.destination_family_name_kana + current_user.destination.destination_first_name_kana
     .contents__btn
       .contents__btn--alert
         -# 配送先と支払い方法の入力を完了してください。

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -3,7 +3,7 @@
     = link_to image_tag('logo.png'), root_path, alt: 'Furima', height: '55', class: 'header-logo'
   %main
     %section.sell-container
-      = form_with id: form, model: @item, url: items_path do |f|
+      = form_with model: @item, url: items_path, id: "form" do |f|
 
         -# 画像部分
         .sell-container__content

--- a/spec/controllers/creditcards_controller_spec.rb
+++ b/spec/controllers/creditcards_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+describe CreditcardsController, type: :controller do
+  context "createアクションにアクセスした時" do
+    before do
+      payjp_customer = double("Payjp::Customer")
+      payjp_list = double("Payjp::ListObject")
+      payjp_card = double("Payjp::Card")
+      allow(Payjp::Customer).to receive(:create).and_return(payjp_customer)        
+      allow(payjp_customer).to receive(:cards).and_return(payjp_list)        
+      allow(payjp_list).to receive(:create).and_return(payjp_card) 
+      allow(payjp_customer).to receive(:id).and_return("cus_xxxxxxxxxxxxx")
+    end
+    it "@creditが定義されていること" do
+      post :create, params: {token: "tok_xxxxxxxx"}
+      creditcard = create(:creditcard, user_id: user.id, customer_id: "cus_xxxxxxxxxxxxx")
+      expect(assigns(:credit).customer_id).to eq(creditcard.customer_id)
+    end
+  end
+
+
+end

--- a/spec/factories/creditcards.rb
+++ b/spec/factories/creditcards.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  
+  factory :creditcard do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
 
   factory :user do
+    id                    {"1"}
     nickname              {"sample"}
     email                 {"sample@gmail.com"}
     password              {"aaaaaa123"}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,131 +1,131 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-describe User do
-  describe '#create' do
+# describe User do
+#   describe '#create' do
 
-    it "is valid with a nickname, email, password, password_confirmation, family_name, first_name, family_name_kana, first_name_kana" do
-      user = build(:user)
-      expect(user).to be_valid
-    end
+#     it "is valid with a nickname, email, password, password_confirmation, family_name, first_name, family_name_kana, first_name_kana" do
+#       user = build(:user)
+#       expect(user).to be_valid
+#     end
 
-    it "is invalid without a nickname" do
-      user = build(:user, nickname: nil)
-      user.valid?
-      expect(user.errors[:nickname]).to include("を入力してください")
-    end
+#     it "is invalid without a nickname" do
+#       user = build(:user, nickname: nil)
+#       user.valid?
+#       expect(user.errors[:nickname]).to include("を入力してください")
+#     end
 
-    it "is invalid without a email" do
-      user = build(:user, email: nil)
-      user.valid?
-      expect(user.errors[:email]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a email" do
+#       user = build(:user, email: nil)
+#       user.valid?
+#       expect(user.errors[:email]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a password" do
-      user = build(:user, password: nil)
-      user.valid?
-      expect(user.errors[:password]).to include("を入力してください", "は7文字以上で入力してください")
-    end
+#     it "is invalid without a password" do
+#       user = build(:user, password: nil)
+#       user.valid?
+#       expect(user.errors[:password]).to include("を入力してください", "は7文字以上で入力してください")
+#     end
 
-    it "is invalid without a password_confirmation" do
-      user = build(:user, password_confirmation: "")
-      user.valid?
-      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
-    end
+#     it "is invalid without a password_confirmation" do
+#       user = build(:user, password_confirmation: "")
+#       user.valid?
+#       expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
+#     end
 
-    it "is valid with a password that has more than 7 characters " do
-      user = build(:user, password: "aaaaaa123", password_confirmation: "aaaaaa123")
-      expect(user).to be_valid
-    end
+#     it "is valid with a password that has more than 7 characters " do
+#       user = build(:user, password: "aaaaaa123", password_confirmation: "aaaaaa123")
+#       expect(user).to be_valid
+#     end
 
-    it "is invalid with a password that has less than 6 characters " do
-      user = build(:user, password: "aaaaaa", password_confirmation: "aaaaaa")
-      user.valid?
-      expect(user.errors[:password]).to include("は7文字以上で入力してください")
-    end
+#     it "is invalid with a password that has less than 6 characters " do
+#       user = build(:user, password: "aaaaaa", password_confirmation: "aaaaaa")
+#       user.valid?
+#       expect(user.errors[:password]).to include("は7文字以上で入力してください")
+#     end
 
-    it "is invalid with a duplicate email address" do
-      user = create(:user)
-      another_user = build(:user, email: user.email)
-      another_user.valid?
-      expect(another_user.errors[:email]).to include("はすでに存在します")
-    end
+#     it "is invalid with a duplicate email address" do
+#       user = create(:user)
+#       another_user = build(:user, email: user.email)
+#       another_user.valid?
+#       expect(another_user.errors[:email]).to include("はすでに存在します")
+#     end
 
-    it "is invalid without a family_name" do
-      user = build(:user, family_name: nil)
-      user.valid?
-      expect(user.errors[:family_name]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a family_name" do
+#       user = build(:user, family_name: nil)
+#       user.valid?
+#       expect(user.errors[:family_name]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a first_name" do
-      user = build(:user, first_name: nil)
-      user.valid?
-      expect(user.errors[:first_name]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a first_name" do
+#       user = build(:user, first_name: nil)
+#       user.valid?
+#       expect(user.errors[:first_name]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a family_name_kana" do
-      user = build(:user, family_name_kana: nil)
-      user.valid?
-      expect(user.errors[:family_name_kana]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a family_name_kana" do
+#       user = build(:user, family_name_kana: nil)
+#       user.valid?
+#       expect(user.errors[:family_name_kana]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a first_name_kana" do
-      user = build(:user, first_name_kana: nil)
-      user.valid?
-      expect(user.errors[:first_name_kana]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a first_name_kana" do
+#       user = build(:user, first_name_kana: nil)
+#       user.valid?
+#       expect(user.errors[:first_name_kana]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a birthday" do
-      user = build(:user, birthday: nil)
-      user.valid?
-      expect(user.errors[:birthday]).to include("を入力してください")
-    end
+#     it "is invalid without a birthday" do
+#       user = build(:user, birthday: nil)
+#       user.valid?
+#       expect(user.errors[:birthday]).to include("を入力してください")
+#     end
 
-    it "is invalid without a destination_family_name" do
-      destination = build(:user, destination_family_name: nil)
-      destination.valid?
-      expect(destination.errors[:destination_family_name]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a destination_family_name" do
+#       destination = build(:user, destination_family_name: nil)
+#       destination.valid?
+#       expect(destination.errors[:destination_family_name]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a destination_first_name" do
-      destination = build(:user, destination_first_name: nil)
-      destination.valid?
-      expect(destination.errors[:destination_first_name]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a destination_first_name" do
+#       destination = build(:user, destination_first_name: nil)
+#       destination.valid?
+#       expect(destination.errors[:destination_first_name]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a destination_family_name_kana" do
-      destination = build(:user, destination_family_name_kana: nil)
-      destination.valid?
-      expect(destination.errors[:destination_family_name_kana]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a destination_family_name_kana" do
+#       destination = build(:user, destination_family_name_kana: nil)
+#       destination.valid?
+#       expect(destination.errors[:destination_family_name_kana]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a destination_first_name_kana" do
-      destination = build(:user, destination_first_name_kana: nil)
-      destination.valid?
-      expect(destination.errors[:destination_first_name_kana]).to include("を入力してください", "は不正な値です")
-    end
+#     it "is invalid without a destination_first_name_kana" do
+#       destination = build(:user, destination_first_name_kana: nil)
+#       destination.valid?
+#       expect(destination.errors[:destination_first_name_kana]).to include("を入力してください", "は不正な値です")
+#     end
 
-    it "is invalid without a postal_code" do
-      destination = build(:user, postal_code: nil)
-      destination.valid?
-      expect(destination.errors[:postal_code]).to include("を入力してください")
-    end
+#     it "is invalid without a postal_code" do
+#       destination = build(:user, postal_code: nil)
+#       destination.valid?
+#       expect(destination.errors[:postal_code]).to include("を入力してください")
+#     end
 
-    it "is invalid without a prefecture_id" do
-      destination = build(:user, prefecture_id: nil)
-      destination.valid?
-      expect(destination.errors[:prefecture_id]).to include("を入力してください")
-    end
+#     it "is invalid without a prefecture_id" do
+#       destination = build(:user, prefecture_id: nil)
+#       destination.valid?
+#       expect(destination.errors[:prefecture_id]).to include("を入力してください")
+#     end
 
-    it "is invalid without a city" do
-      destination = build(:user, city: nil)
-      destination.valid?
-      expect(destination.errors[:city]).to include("を入力してください")
-    end
+#     it "is invalid without a city" do
+#       destination = build(:user, city: nil)
+#       destination.valid?
+#       expect(destination.errors[:city]).to include("を入力してください")
+#     end
 
-    it "is invalid without a house_number" do
-      destination = build(:user, house_number: nil)
-      destination.valid?
-      expect(destination.errors[:house_number]).to include("を入力してください")
-    end
-  end
-end 
+#     it "is invalid without a house_number" do
+#       destination = build(:user, house_number: nil)
+#       destination.valid?
+#       expect(destination.errors[:house_number]).to include("を入力してください")
+#     end
+#   end
+# end 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,131 +1,131 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# describe User do
-#   describe '#create' do
+describe User do
+  describe '#create' do
 
-#     it "is valid with a nickname, email, password, password_confirmation, family_name, first_name, family_name_kana, first_name_kana" do
-#       user = build(:user)
-#       expect(user).to be_valid
-#     end
+    it "is valid with a nickname, email, password, password_confirmation, family_name, first_name, family_name_kana, first_name_kana" do
+      user = build(:user)
+      expect(user).to be_valid
+    end
 
-#     it "is invalid without a nickname" do
-#       user = build(:user, nickname: nil)
-#       user.valid?
-#       expect(user.errors[:nickname]).to include("を入力してください")
-#     end
+    it "is invalid without a nickname" do
+      user = build(:user, nickname: nil)
+      user.valid?
+      expect(user.errors[:nickname]).to include("を入力してください")
+    end
 
-#     it "is invalid without a email" do
-#       user = build(:user, email: nil)
-#       user.valid?
-#       expect(user.errors[:email]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a email" do
+      user = build(:user, email: nil)
+      user.valid?
+      expect(user.errors[:email]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a password" do
-#       user = build(:user, password: nil)
-#       user.valid?
-#       expect(user.errors[:password]).to include("を入力してください", "は7文字以上で入力してください")
-#     end
+    it "is invalid without a password" do
+      user = build(:user, password: nil)
+      user.valid?
+      expect(user.errors[:password]).to include("を入力してください", "は7文字以上で入力してください")
+    end
 
-#     it "is invalid without a password_confirmation" do
-#       user = build(:user, password_confirmation: "")
-#       user.valid?
-#       expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
-#     end
+    it "is invalid without a password_confirmation" do
+      user = build(:user, password_confirmation: "")
+      user.valid?
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
+    end
 
-#     it "is valid with a password that has more than 7 characters " do
-#       user = build(:user, password: "aaaaaa123", password_confirmation: "aaaaaa123")
-#       expect(user).to be_valid
-#     end
+    it "is valid with a password that has more than 7 characters " do
+      user = build(:user, password: "aaaaaa123", password_confirmation: "aaaaaa123")
+      expect(user).to be_valid
+    end
 
-#     it "is invalid with a password that has less than 6 characters " do
-#       user = build(:user, password: "aaaaaa", password_confirmation: "aaaaaa")
-#       user.valid?
-#       expect(user.errors[:password]).to include("は7文字以上で入力してください")
-#     end
+    it "is invalid with a password that has less than 6 characters " do
+      user = build(:user, password: "aaaaaa", password_confirmation: "aaaaaa")
+      user.valid?
+      expect(user.errors[:password]).to include("は7文字以上で入力してください")
+    end
 
-#     it "is invalid with a duplicate email address" do
-#       user = create(:user)
-#       another_user = build(:user, email: user.email)
-#       another_user.valid?
-#       expect(another_user.errors[:email]).to include("はすでに存在します")
-#     end
+    it "is invalid with a duplicate email address" do
+      user = create(:user)
+      another_user = build(:user, email: user.email)
+      another_user.valid?
+      expect(another_user.errors[:email]).to include("はすでに存在します")
+    end
 
-#     it "is invalid without a family_name" do
-#       user = build(:user, family_name: nil)
-#       user.valid?
-#       expect(user.errors[:family_name]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a family_name" do
+      user = build(:user, family_name: nil)
+      user.valid?
+      expect(user.errors[:family_name]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a first_name" do
-#       user = build(:user, first_name: nil)
-#       user.valid?
-#       expect(user.errors[:first_name]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a first_name" do
+      user = build(:user, first_name: nil)
+      user.valid?
+      expect(user.errors[:first_name]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a family_name_kana" do
-#       user = build(:user, family_name_kana: nil)
-#       user.valid?
-#       expect(user.errors[:family_name_kana]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a family_name_kana" do
+      user = build(:user, family_name_kana: nil)
+      user.valid?
+      expect(user.errors[:family_name_kana]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a first_name_kana" do
-#       user = build(:user, first_name_kana: nil)
-#       user.valid?
-#       expect(user.errors[:first_name_kana]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a first_name_kana" do
+      user = build(:user, first_name_kana: nil)
+      user.valid?
+      expect(user.errors[:first_name_kana]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a birthday" do
-#       user = build(:user, birthday: nil)
-#       user.valid?
-#       expect(user.errors[:birthday]).to include("を入力してください")
-#     end
+    it "is invalid without a birthday" do
+      user = build(:user, birthday: nil)
+      user.valid?
+      expect(user.errors[:birthday]).to include("を入力してください")
+    end
 
-#     it "is invalid without a destination_family_name" do
-#       destination = build(:user, destination_family_name: nil)
-#       destination.valid?
-#       expect(destination.errors[:destination_family_name]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a destination_family_name" do
+      destination = build(:user, destination_family_name: nil)
+      destination.valid?
+      expect(destination.errors[:destination_family_name]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a destination_first_name" do
-#       destination = build(:user, destination_first_name: nil)
-#       destination.valid?
-#       expect(destination.errors[:destination_first_name]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a destination_first_name" do
+      destination = build(:user, destination_first_name: nil)
+      destination.valid?
+      expect(destination.errors[:destination_first_name]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a destination_family_name_kana" do
-#       destination = build(:user, destination_family_name_kana: nil)
-#       destination.valid?
-#       expect(destination.errors[:destination_family_name_kana]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a destination_family_name_kana" do
+      destination = build(:user, destination_family_name_kana: nil)
+      destination.valid?
+      expect(destination.errors[:destination_family_name_kana]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a destination_first_name_kana" do
-#       destination = build(:user, destination_first_name_kana: nil)
-#       destination.valid?
-#       expect(destination.errors[:destination_first_name_kana]).to include("を入力してください", "は不正な値です")
-#     end
+    it "is invalid without a destination_first_name_kana" do
+      destination = build(:user, destination_first_name_kana: nil)
+      destination.valid?
+      expect(destination.errors[:destination_first_name_kana]).to include("を入力してください", "は不正な値です")
+    end
 
-#     it "is invalid without a postal_code" do
-#       destination = build(:user, postal_code: nil)
-#       destination.valid?
-#       expect(destination.errors[:postal_code]).to include("を入力してください")
-#     end
+    it "is invalid without a postal_code" do
+      destination = build(:user, postal_code: nil)
+      destination.valid?
+      expect(destination.errors[:postal_code]).to include("を入力してください")
+    end
 
-#     it "is invalid without a prefecture_id" do
-#       destination = build(:user, prefecture_id: nil)
-#       destination.valid?
-#       expect(destination.errors[:prefecture_id]).to include("を入力してください")
-#     end
+    it "is invalid without a prefecture_id" do
+      destination = build(:user, prefecture_id: nil)
+      destination.valid?
+      expect(destination.errors[:prefecture_id]).to include("を入力してください")
+    end
 
-#     it "is invalid without a city" do
-#       destination = build(:user, city: nil)
-#       destination.valid?
-#       expect(destination.errors[:city]).to include("を入力してください")
-#     end
+    it "is invalid without a city" do
+      destination = build(:user, city: nil)
+      destination.valid?
+      expect(destination.errors[:city]).to include("を入力してください")
+    end
 
-#     it "is invalid without a house_number" do
-#       destination = build(:user, house_number: nil)
-#       destination.valid?
-#       expect(destination.errors[:house_number]).to include("を入力してください")
-#     end
-#   end
-# end 
+    it "is invalid without a house_number" do
+      destination = build(:user, house_number: nil)
+      destination.valid?
+      expect(destination.errors[:house_number]).to include("を入力してください")
+    end
+  end
+end 

--- a/spec/support/payjp_mock.rb
+++ b/spec/support/payjp_mock.rb
@@ -1,0 +1,49 @@
+module PayjpMock
+  def self.prepare_customer_information # Payjp::Customerのレスポンスモック
+    {
+      "id": "cus_ca9d1d98900ec1f2595aebefd9a6",
+      "cards": {
+        "count":1,
+        "data":[{
+          "id":"car_a96c76b044d7ae21439d7b9840b7",
+          "address_city":nil,
+          "address_line1":nil,
+          "address_line2":nil,
+          "address_state":nil,
+          "address_zip":nil,
+          "address_zip_check":"unchecked",
+          "brand":"Visa",
+          "country":nil,
+          "created":1578830630,
+          "customer":"cus_ca9d1d98900ec1f2595aebefd9a6",
+          "cvc_check":"passed",
+          "exp_month":12,
+          "exp_year":2020,
+          "fingerprint":"e1d8225886e3a7211127df751c86787f",
+          "last4":"4242",
+          "livemode":false,
+          "metadata":{},
+          "name":nil,
+          "object":"card"
+          }],
+          "has_more":false,
+          "object":"list",
+          "url":"/v1/customers/cus_ca9d1d98900ec1f2595aebefd9a6/cards"
+        },
+      "created": 1578830631,
+      "default_card": "car_a96c76b044d7ae21439d7b9840b7",
+      "description": nil,
+      "email": nil,
+      "livemode": false,
+      "metadata": {},
+      "object": "customer",
+      "subscriptions": {
+        "count":0,
+        "data":[],
+        "has_more":false,
+        "object":"list",
+        "url":"/v1/customers/cus_ca9d1d98900ec1f2595aebefd9a6/subscriptions"
+      }
+    }
+  end
+end


### PR DESCRIPTION
# What
実際にクレジットカードを登録して商品を購入できるようにします。
クレジットカードを登録する際カード番号は
https://pay.jp/docs/testcard
このURLに記載されているいずれかのカード番号を用いて登録できます、有効期限とcvcは任意です。

マイページの実装の際にクレジットカード関係の実装が終わってしまっていたので今回のプルリクエストでは修正が主にメインになってしまっています

# Why
クレジットカードを用いて実際に商品の取引ができなければフリマアプリの機能を果たせないから。